### PR TITLE
[1.1.2] advanced_nic: VLAN doesn't work

### DIFF
--- a/inventory/cluster/nodes/iceberg1/managements.yml
+++ b/inventory/cluster/nodes/iceberg1/managements.yml
@@ -24,6 +24,10 @@ mg_managements:                        # Master group
               type: bond-slave
               master: bond0
 
-            eth2.100:
+            eth2.100:                       # To define an interface in a VLAN
+              ip4: 10.100.0.1
+              mac: a0:36:9f:2e:c1:41
+              physical_device: eth2
+              vlan_id: 100
               vlan: true
-
+              network: ice1-100


### PR DESCRIPTION
Hello,
the feature 'adding an interface with vlan' doesn't work in this role version.
Here the patch for fixes the problem.
Regards,
HME

My patch to the role: https://github.com/bluebanquise/bluebanquise/commit/5f352a1153cc6b47336fb4c641a37b056fdf8163 